### PR TITLE
fix(usecase): email validation returns 422 instead of 500 (name-aware DTO validate tags)

### DIFF
--- a/cmd/usecase.go
+++ b/cmd/usecase.go
@@ -584,7 +584,7 @@ func generateCreateDTOWithFields(content *strings.Builder, entity string, valida
 		jsonTag := fmt.Sprintf("json:\"%s\"", strings.ToLower(field.Name))
 
 		if validation {
-			validateTag := getValidationTag(field.Type)
+			validateTag := dtoValidationTag(field)
 			fmt.Fprintf(content, "\t%s %s `%s validate:\"%s\"`\n",
 				field.Name, field.Type, jsonTag, validateTag)
 		} else {
@@ -682,7 +682,7 @@ func generateUpdateDTOWithFields(content *strings.Builder, entity string, valida
 		jsonTag := fmt.Sprintf("json:\"%s,omitempty\"", strings.ToLower(field.Name))
 
 		if validation {
-			validateTag := "omitempty," + getValidationTag(field.Type)
+			validateTag := dtoUpdateValidationTag(field)
 			fmt.Fprintf(content, "\t%s %s `%s validate:\"%s\"`\n",
 				field.Name, fieldType, jsonTag, validateTag)
 		} else {
@@ -709,6 +709,31 @@ func getValidationTag(fieldType string) string {
 	default:
 		return "required"
 	}
+}
+
+// dtoValidationTag returns the `validate` struct tag for a Create DTO field. It
+// is name-aware so email fields are validated for format at the HTTP layer
+// (returning 422), instead of only being caught by the domain Validate()
+// (which would surface as a 500).
+func dtoValidationTag(field Field) string {
+	if field.Type == "string" && strings.Contains(strings.ToLower(field.Name), "email") {
+		return "required,email"
+	}
+	return getValidationTag(field.Type)
+}
+
+// dtoUpdateValidationTag returns the `validate` tag for an optional Update DTO
+// field (pointer), keeping format checks but not requiring presence.
+func dtoUpdateValidationTag(field Field) string {
+	base := dtoValidationTag(field)
+	base = strings.TrimPrefix(base, "required,")
+	if base == "required" {
+		base = ""
+	}
+	if base == "" {
+		return "omitempty"
+	}
+	return "omitempty," + base
 }
 
 // ensureImportInDTOFile ensures a specific import exists in the DTO file content.


### PR DESCRIPTION
## Summary

Deep runtime verification of 1.25.4 (running the full CRUD lifecycle and exercising validation) found that **a malformed email returned HTTP 500** instead of a client error.

The generated Create DTO used a type-only `validate` struct tag (`required,min=1`), so `validator.Struct(input)` accepted a non-empty-but-invalid email; the bad value was then only caught by the domain `Validate()`, which the handler maps to 500.

## Fix

DTO `validate` tags are now **field-name-aware**:
- email fields → `validate:"required,email"` (Create) / `validate:"omitempty,email"` (Update)
- other fields keep the existing type-based tags

So the HTTP-layer validator rejects malformed emails with **422 Unprocessable Entity** before reaching the use case.

## Verification (real SQLite server)

```
POST /api/v1/accounts {"name":"Bob","email":"bob@x.com"}   -> 201
POST /api/v1/accounts {"name":"Bob","email":"notanemail"}  -> 422  (was 500)
POST /api/v1/accounts {"email":"x@y.com"}                  -> 422  (missing name)
```

Also confirmed in this pass: the **full CRUD lifecycle works end-to-end** against a real SQLite DB:
`POST → 201`, `GET list → 200`, `GET /{id} → 200`, `PUT → 204`, `GET → reflects update`, `DELETE → 204`, `GET → 404 record not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)