### PR TITLE
fix: stabilization batch — ~10 generator bugs (entities, CLI, mocks, DI, config)

### DIFF
--- a/cmd/cache_helpers_test.go
+++ b/cmd/cache_helpers_test.go
@@ -116,7 +116,7 @@ func TestGenerateSetupRepositories_WithCacheMySQL(t *testing.T) {
 	generateSetupRepositories(&b, []string{"Order"}, "mysql", true)
 	output := b.String()
 
-	assert.Contains(t, output, "baseOrderRepo := repository.NewMySQLOrderRepository(c.db)")
+	assert.Contains(t, output, "baseOrderRepo := repository.NewPostgresOrderRepository(c.db)")
 	assert.Contains(t, output, "c.orderRepo = repository.NewCachedOrderRepository(baseOrderRepo, c.redisClient, 5*time.Minute)")
 }
 

--- a/cmd/config_manager.go
+++ b/cmd/config_manager.go
@@ -374,7 +374,9 @@ func (cm *ConfigManager) validateArchitecture(arch *ArchitectureConfig) {
 
 // validateDatabase validates database configuration.
 func (cm *ConfigManager) validateDatabase(db *DatabaseConfig) {
-	validDBTypes := []string{"postgres", "mysql", "mongodb", "sqlite"}
+	// Must stay in sync with the database types init/feature accept; otherwise a
+	// generated config fails to load and the project falls back to defaults.
+	validDBTypes := []string{"postgres", "postgres-json", "mysql", "mongodb", "sqlite", "sqlserver", "dynamodb", "elasticsearch"}
 	if !cm.contains(validDBTypes, db.Type) {
 		cm.addError("database.type", "invalid database type", db.Type)
 	}

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -175,13 +175,10 @@ func generateSetupRepositories(content *strings.Builder, features []string, data
 		featureLower := strings.ToLower(feature)
 		var repoConstructor string
 		switch database {
-		case dbPostgres:
-			repoConstructor = fmt.Sprintf("repository.NewPostgres%sRepository(c.db)", feature)
-		case dbMySQL:
-			repoConstructor = fmt.Sprintf("repository.NewMySQL%sRepository(c.db)", feature)
 		case dbMongoDB:
 			repoConstructor = fmt.Sprintf("repository.NewMongo%sRepository(c.db)", feature)
 		default:
+			// All SQL databases use the shared GORM constructor.
 			repoConstructor = fmt.Sprintf("repository.NewPostgres%sRepository(c.db)", feature)
 		}
 
@@ -310,13 +307,10 @@ func writeRepositorySet(content *strings.Builder, features []string, database st
 	content.WriteString("\tRepositorySet = wire.NewSet(\n")
 	for _, feature := range features {
 		switch database {
-		case dbPostgres:
-			fmt.Fprintf(content, "\t\trepository.NewPostgres%sRepository,\n", feature)
-		case dbMySQL:
-			fmt.Fprintf(content, "\t\trepository.NewMySQL%sRepository,\n", feature)
 		case dbMongoDB:
 			fmt.Fprintf(content, "\t\trepository.NewMongo%sRepository,\n", feature)
 		default:
+			// All SQL databases use the shared GORM constructor.
 			fmt.Fprintf(content, "\t\trepository.NewPostgres%sRepository,\n", feature)
 		}
 	}

--- a/cmd/di_helpers_test.go
+++ b/cmd/di_helpers_test.go
@@ -16,7 +16,7 @@ func TestGenerateSetupRepositories(t *testing.T) {
 		prefix   string
 	}{
 		{"postgres", "postgres", "NewPostgres"},
-		{"mysql", "mysql", "NewMySQL"},
+		{"mysql", "mysql", "NewPostgres"},
 		{"mongodb", "mongodb", "NewMongo"},
 		{"default", "other", "NewPostgres"},
 	}
@@ -111,7 +111,7 @@ func TestWriteRepositorySet(t *testing.T) {
 		expected string
 	}{
 		{"postgres", "postgres", "NewPostgresProductRepository"},
-		{"mysql", "mysql", "NewMySQLProductRepository"},
+		{"mysql", "mysql", "NewPostgresProductRepository"},
 		{"mongodb", "mongodb", "NewMongoProductRepository"},
 		{"default", "other", "NewPostgresProductRepository"},
 	}

--- a/cmd/entity.go
+++ b/cmd/entity.go
@@ -506,10 +506,40 @@ func writeErrorsHeader(content *strings.Builder) {
 
 // writeEntityErrors writes all error definitions for the entity.
 func writeEntityErrors(content *strings.Builder, entityName string, fields []Field, existingErrors []string) {
-	writeGeneralError(content, entityName, existingErrors)
-	writeExistingErrors(content, existingErrors)
-	writeFieldErrors(content, entityName, fields, existingErrors)
+	var tmp strings.Builder
+	writeGeneralError(&tmp, entityName, existingErrors)
+	writeExistingErrors(&tmp, existingErrors)
+	writeFieldErrors(&tmp, entityName, fields, existingErrors)
+
+	// Deduplicate by error identifier. For example a field named "data" yields
+	// ErrInvalid<Entity>Data, which collides with the general
+	// ErrInvalid<Entity>Data constant and would otherwise be redeclared.
+	seen := make(map[string]bool)
+	for _, line := range strings.Split(tmp.String(), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if id := errorIdentifier(line); id != "" {
+			if seen[id] {
+				continue
+			}
+			seen[id] = true
+		}
+		content.WriteString(line + "\n")
+	}
 	content.WriteString(")\n")
+}
+
+// errorIdentifier extracts the Err… constant name from a declaration line.
+func errorIdentifier(line string) string {
+	t := strings.TrimSpace(line)
+	if !strings.HasPrefix(t, "Err") {
+		return ""
+	}
+	if i := strings.IndexAny(t, " ="); i > 0 {
+		return t[:i]
+	}
+	return ""
 }
 
 // writeGeneralError writes the general entity error.

--- a/cmd/field_validator.go
+++ b/cmd/field_validator.go
@@ -480,7 +480,7 @@ func (v *FieldValidator) ValidateReservedNames(name string) error {
 
 	for _, conflict := range conflictNames {
 		if strings.EqualFold(lowerName, conflict) {
-			return fmt.Errorf("'%s' puede causar conflicts. Usa un nombre diferente", name)
+			return fmt.Errorf("'%s' may cause naming conflicts; use a different name", name)
 		}
 	}
 

--- a/cmd/handler_other.go
+++ b/cmd/handler_other.go
@@ -184,6 +184,43 @@ func generateGRPCServerFile(dir, entity, fileNamingConvention string, sm ...*Saf
 	}
 }
 
+// cliFlagFor returns the cobra flag accessor expression and declaration line
+// for a CLI command flag matching the given entity field. It reports ok=false
+// for types without a natural scalar flag (slices, maps, time, custom), which
+// are then omitted from the command.
+func cliFlagFor(field Field, entityLower string) (getExpr, flagDecl string, ok bool) {
+	flag := strings.ToLower(field.Name)
+	usage := fmt.Sprintf("%s of the %s", field.Name, entityLower)
+	switch field.Type {
+	case "string":
+		return fmt.Sprintf("cmd.Flags().GetString(%q)", flag),
+			fmt.Sprintf("\tcmd.Flags().String(%q, \"\", %q)\n", flag, usage), true
+	case "int":
+		return fmt.Sprintf("cmd.Flags().GetInt(%q)", flag),
+			fmt.Sprintf("\tcmd.Flags().Int(%q, 0, %q)\n", flag, usage), true
+	case "int64":
+		return fmt.Sprintf("cmd.Flags().GetInt64(%q)", flag),
+			fmt.Sprintf("\tcmd.Flags().Int64(%q, 0, %q)\n", flag, usage), true
+	case "uint":
+		return fmt.Sprintf("cmd.Flags().GetUint(%q)", flag),
+			fmt.Sprintf("\tcmd.Flags().Uint(%q, 0, %q)\n", flag, usage), true
+	case "uint64":
+		return fmt.Sprintf("cmd.Flags().GetUint64(%q)", flag),
+			fmt.Sprintf("\tcmd.Flags().Uint64(%q, 0, %q)\n", flag, usage), true
+	case "float64":
+		return fmt.Sprintf("cmd.Flags().GetFloat64(%q)", flag),
+			fmt.Sprintf("\tcmd.Flags().Float64(%q, 0, %q)\n", flag, usage), true
+	case "float32":
+		return fmt.Sprintf("cmd.Flags().GetFloat32(%q)", flag),
+			fmt.Sprintf("\tcmd.Flags().Float32(%q, 0, %q)\n", flag, usage), true
+	case "bool":
+		return fmt.Sprintf("cmd.Flags().GetBool(%q)", flag),
+			fmt.Sprintf("\tcmd.Flags().Bool(%q, false, %q)\n", flag, usage), true
+	default:
+		return "", "", false
+	}
+}
+
 func generateCLIHandler(entity, fileNamingConvention string, sm ...*SafetyManager) {
 	// Create CLI directory
 	cliDir := filepath.Join(DirInternal, DirHandler, DirCLI)
@@ -224,46 +261,59 @@ func generateCLIHandler(entity, fileNamingConvention string, sm ...*SafetyManage
 	content.WriteString(fmt.Sprintf("\treturn &%sCLI{usecase: uc}\n", entity))
 	content.WriteString("}\n\n")
 
-	// Create command
+	// Create command — flags and input are derived from the real entity fields.
+	var cliFields []Field
+	if fs := readEntityFieldsString(entity); fs != "" {
+		cliFields = parseFields(fs)
+	}
 	content.WriteString(fmt.Sprintf("func (c *%sCLI) Create%sCommand() *cobra.Command {\n", entity, entity))
 	content.WriteString("\tcmd := &cobra.Command{\n")
-	content.WriteString("\t\tUse:   \"crear\",\n")
-	content.WriteString(fmt.Sprintf("\t\tShort: \"Crear un nuevo %s\",\n", entityLower))
+	content.WriteString(fmt.Sprintf("\t\tUse:   \"create\",\n\t\tShort: \"Create a new %s\",\n", entityLower))
 	content.WriteString("\t\tRun: func(cmd *cobra.Command, args []string) {\n")
-	content.WriteString("\t\t\tname, _ := cmd.Flags().GetString(\"name\")\n")
-	content.WriteString("\t\t\temail, _ := cmd.Flags().GetString(\"email\")\n\n")
 
-	content.WriteString(fmt.Sprintf("\t\t\tinput := usecase.Create%sInput{\n", entity))
-	content.WriteString("\t\t\t\tName:  name,\n")
-	content.WriteString("\t\t\t\tEmail: email,\n")
+	var flagDecls strings.Builder
+	for _, f := range cliFields {
+		if isSystemField(f.Name) {
+			continue
+		}
+		getExpr, flagDecl, ok := cliFlagFor(f, entityLower)
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(&content, "\t\t\t%s, _ := %s\n", strings.ToLower(f.Name), getExpr)
+		flagDecls.WriteString(flagDecl)
+	}
+	content.WriteString("\n")
+
+	fmt.Fprintf(&content, "\t\t\tinput := usecase.Create%sInput{\n", entity)
+	for _, f := range cliFields {
+		if isSystemField(f.Name) {
+			continue
+		}
+		if _, _, ok := cliFlagFor(f, entityLower); !ok {
+			continue
+		}
+		fmt.Fprintf(&content, "\t\t\t\t%s: %s,\n", f.Name, strings.ToLower(f.Name))
+	}
 	content.WriteString("\t\t\t}\n\n")
 
-	content.WriteString(fmt.Sprintf("\t\t\toutput, err := c.usecase.Create%s(input)\n", entity))
+	fmt.Fprintf(&content, "\t\t\toutput, err := c.usecase.Create%s(input)\n", entity)
 	content.WriteString("\t\t\tif err != nil {\n")
 	content.WriteString("\t\t\t\tfmt.Printf(\"Error: %v\\n\", err)\n")
 	content.WriteString("\t\t\t\treturn\n")
 	content.WriteString("\t\t\t}\n\n")
-
-	content.WriteString(fmt.Sprintf("\t\t\tfmt.Printf(\"%s created: %%+v\\n\", output.%s)\n", entity, entity))
+	fmt.Fprintf(&content, "\t\t\tfmt.Printf(\"%s created: %%+v\\n\", output)\n", entity)
 	content.WriteString("\t\t},\n")
 	content.WriteString("\t}\n\n")
-
-	content.WriteString("\tcmd.Flags().StringP(\"name\", \"n\", \"\", \"Name of the ")
-	content.WriteString(entityLower)
-	content.WriteString("\")\n")
-	content.WriteString("\tcmd.Flags().StringP(\"email\", \"e\", \"\", \"Email of the ")
-	content.WriteString(entityLower)
-	content.WriteString("\")\n")
-	content.WriteString("\tcmd.MarkFlagRequired(\"name\")\n")
-	content.WriteString("\tcmd.MarkFlagRequired(\"email\")\n\n")
+	content.WriteString(flagDecls.String())
 	content.WriteString("\treturn cmd\n")
 	content.WriteString("}\n\n")
 
 	// Get command
 	content.WriteString(fmt.Sprintf("func (c *%sCLI) Get%sCommand() *cobra.Command {\n", entity, entity))
 	content.WriteString("\treturn &cobra.Command{\n")
-	content.WriteString("\t\tUse:   \"obtener [id]\",\n")
-	content.WriteString(fmt.Sprintf("\t\tShort: \"Obtener %s por ID\",\n", entityLower))
+	content.WriteString("\t\tUse:   \"get [id]\",\n")
+	content.WriteString(fmt.Sprintf("\t\tShort: \"Get %s by ID\",\n", entityLower))
 	content.WriteString("\t\tArgs:  cobra.ExactArgs(1),\n")
 	content.WriteString("\t\tRun: func(cmd *cobra.Command, args []string) {\n")
 	content.WriteString("\t\t\tid, err := strconv.Atoi(args[0])\n")

--- a/cmd/integrate.go
+++ b/cmd/integrate.go
@@ -78,10 +78,11 @@ func detectExistingFeatures() []string {
 				name := strings.TrimSuffix(entry.Name(), ".go")
 				// Skip common files, seed files and test files
 				if name != "errors" && name != "validations" && name != "common" && !strings.HasSuffix(name, "_seeds") && !strings.HasSuffix(name, "_test") {
-					// Capitalize first letter to match feature naming
+					// Reconstruct the PascalCase feature name from the snake_case
+					// file name (e.g. user_profile.go -> UserProfile) so multi-word
+					// entities are wired under their real type name.
 					if len(name) > 0 {
-						caser := cases.Title(language.English)
-						features = append(features, caser.String(name))
+						features = append(features, snakeToPascal(name))
 					}
 				}
 			}
@@ -94,8 +95,7 @@ func detectExistingFeatures() []string {
 		for _, entry := range entries {
 			if !entry.IsDir() && strings.HasSuffix(entry.Name(), "_handler.go") {
 				name := strings.TrimSuffix(entry.Name(), "_handler.go")
-				caser := cases.Title(language.English)
-				featureName := caser.String(name)
+				featureName := snakeToPascal(name)
 
 				// Only add if not already in the list
 				found := false
@@ -131,6 +131,17 @@ func integrateFeatures(features []string, sm ...*SafetyManager) {
 	// Step 3: Verify integration
 	ui.Step(3, "Verifying integration...")
 	verifyIntegration(features)
+}
+
+// snakeToPascal converts a snake_case identifier to PascalCase
+// (e.g. "user_profile" -> "UserProfile", "user" -> "User").
+func snakeToPascal(s string) string {
+	caser := cases.Title(language.English)
+	parts := strings.Split(s, "_")
+	for i, p := range parts {
+		parts[i] = caser.String(p)
+	}
+	return strings.Join(parts, "")
 }
 
 // createOrUpdateDIContainer creates or updates the DI container with all features.

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -109,6 +109,10 @@ func generateUseCaseMessages(entity string, sm ...*SafetyManager) {
 		// File exists, read it
 		if content, err := os.ReadFile(filename); err == nil {
 			existing := string(content)
+			// Idempotent: skip if this entity's messages already exist.
+			if strings.Contains(existing, fmt.Sprintf("%sCreated ", entity)) {
+				return
+			}
 			// Remove the closing parenthesis and const block end
 			if strings.Contains(existing, ")\n") {
 				existing = strings.ReplaceAll(existing, ")\n", "")
@@ -151,6 +155,10 @@ func generateResponseMessages(dir, entity string, sm ...*SafetyManager) {
 		// File exists, read it
 		if content, err := os.ReadFile(filename); err == nil {
 			existing := string(content)
+			// Idempotent: skip if this entity's response messages already exist.
+			if strings.Contains(existing, fmt.Sprintf("%sCreatedSuccessfully ", entity)) {
+				return
+			}
 			// Remove the closing parenthesis and const block end
 			if strings.Contains(existing, ")\n") {
 				existing = strings.ReplaceAll(existing, ")\n", "")

--- a/cmd/mocks.go
+++ b/cmd/mocks.go
@@ -101,10 +101,12 @@ func generateMocks(entityName string, all, repository, usecase, handler bool, sm
 		return err
 	}
 
+	importPath := getImportPath(getModuleName())
+
 	// Generate repository mock
 	if all || repository {
 		mockFile := filepath.Join(mocksDir, fmt.Sprintf("mock_%s_repository.go", strings.ToLower(entityName)))
-		content := generateRepositoryMock(entityName)
+		content := fixGeneratedModulePath(generateRepositoryMock(entityName), importPath)
 		if err := writeFile(mockFile, content, sm...); err != nil {
 			return err
 		}
@@ -113,7 +115,7 @@ func generateMocks(entityName string, all, repository, usecase, handler bool, sm
 	// Generate use case mock
 	if all || usecase {
 		mockFile := filepath.Join(mocksDir, fmt.Sprintf("mock_%s_usecase.go", strings.ToLower(entityName)))
-		content := generateUseCaseMock(entityName)
+		content := fixGeneratedModulePath(generateUseCaseMock(entityName), importPath)
 		if err := writeFile(mockFile, content, sm...); err != nil {
 			return err
 		}
@@ -122,7 +124,7 @@ func generateMocks(entityName string, all, repository, usecase, handler bool, sm
 	// Generate handler mock
 	if all || handler {
 		mockFile := filepath.Join(mocksDir, fmt.Sprintf("mock_%s_handler.go", strings.ToLower(entityName)))
-		content := generateHandlerMock(entityName)
+		content := fixGeneratedModulePath(generateHandlerMock(entityName), importPath)
 		if err := writeFile(mockFile, content, sm...); err != nil {
 			return err
 		}
@@ -136,7 +138,7 @@ func generateMocks(entityName string, all, repository, usecase, handler bool, sm
 		}
 
 		exampleFile := filepath.Join(examplesDir, fmt.Sprintf("%s_mock_examples_test.go", strings.ToLower(entityName)))
-		exampleContent := generateMockUsageExamples(entityName)
+		exampleContent := fixGeneratedModulePath(generateMockUsageExamples(entityName), importPath)
 		if err := writeFile(exampleFile, exampleContent, sm...); err != nil {
 			return err
 		}

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -121,10 +121,15 @@ func generateRepository(entity, database string, interfaceOnly, implementation, 
 	repoDir := "internal/repository"
 	_ = os.MkdirAll(repoDir, 0o755)
 
-	// Parse fields if provided
+	// Parse the provided fields, or recover them from the already-generated
+	// entity. Using the field-aware (GORM) generators keeps the repository
+	// consistent with the DI container and the feature command, which expect a
+	// New<DB><Entity>Repository(*gorm.DB) constructor.
 	var parsedFields []Field
 	if fields != "" {
 		parsedFields = parseFields(fields)
+	} else if fs := readEntityFieldsString(entity); fs != "" {
+		parsedFields = parseFields(fs)
 	}
 
 	// Generate interface:
@@ -132,7 +137,7 @@ func generateRepository(entity, database string, interfaceOnly, implementation, 
 	// - interfaceOnly=true: only interface
 	// - interfaceOnly=false, implementation=true: both
 	// - interfaceOnly=false, implementation=false: both (default)
-	if fields != "" {
+	if len(parsedFields) > 0 {
 		generateRepositoryInterfaceWithFields(repoDir, entity, parsedFields, transactions, sm...)
 	} else {
 		generateRepositoryInterface(repoDir, entity, transactions, sm...)
@@ -140,7 +145,7 @@ func generateRepository(entity, database string, interfaceOnly, implementation, 
 
 	// Generate implementation if not interface-only and database is specified
 	if !interfaceOnly && database != "" {
-		if fields != "" {
+		if len(parsedFields) > 0 {
 			generateRepositoryImplementationWithFields(repoDir, entity, database, parsedFields, cache, transactions, sm...)
 		} else {
 			generateRepositoryImplementation(repoDir, entity, database, cache, transactions, sm...)

--- a/cmd/repository_fields.go
+++ b/cmd/repository_fields.go
@@ -78,10 +78,19 @@ func generateRepositoryImplementationWithFields(dir, entity, database string, fi
 	}
 }
 
-// generatePostgresRepositoryWithFields generates PostgreSQL repository with dynamic methods.
+// generatePostgresRepositoryWithFields generates a PostgreSQL repository.
 func generatePostgresRepositoryWithFields(dir, entity string, fields []Field, cache, transactions bool, sm ...*SafetyManager) {
+	generateGormRepositoryWithFields(dir, entity, "Postgres", fields, cache, transactions, sm...)
+}
+
+// generateGormRepositoryWithFields generates a GORM-based repository for the
+// given driver (e.g. "Postgres", "MySQL"). The constructor and file name are
+// driver-prefixed so they match what the DI container references
+// (New<Driver><Entity>Repository).
+func generateGormRepositoryWithFields(dir, entity, driver string, fields []Field, cache, transactions bool, sm ...*SafetyManager) {
 	entityLower := strings.ToLower(entity)
-	filename := filepath.Join(dir, "postgres_"+entityLower+"_repository.go")
+	driverLower := strings.ToLower(driver)
+	filename := filepath.Join(dir, driverLower+"_"+entityLower+"_repository.go")
 
 	// Get the module name from go.mod
 	moduleName := getModuleName()
@@ -102,12 +111,12 @@ func generatePostgresRepositoryWithFields(dir, entity string, fields []Field, ca
 	content.WriteString(")\n\n")
 
 	// Repository structure
-	repoName := fmt.Sprintf("postgres%sRepository", entity)
+	repoName := fmt.Sprintf("%s%sRepository", driverLower, entity)
 	content.WriteString(fmt.Sprintf("type %s struct {\n", repoName))
 	content.WriteString("\tdb *gorm.DB\n")
 	content.WriteString("}\n\n")
 
-	content.WriteString(fmt.Sprintf("func NewPostgres%sRepository(db *gorm.DB) %sRepository {\n", entity, entity))
+	content.WriteString(fmt.Sprintf("func New%s%sRepository(db *gorm.DB) %sRepository {\n", driver, entity, entity))
 	content.WriteString(fmt.Sprintf("\treturn &%s{\n", repoName))
 	content.WriteString("\t\tdb: db,\n")
 	content.WriteString("\t}\n")
@@ -127,7 +136,7 @@ func generatePostgresRepositoryWithFields(dir, entity string, fields []Field, ca
 	}
 
 	if err := writeGoFile(filename, content.String(), sm...); err != nil {
-		fmt.Printf("Error creating PostgreSQL repository with fields: %v\n", err)
+		fmt.Printf("Error creating %s repository with fields: %v\n", driver, err)
 	}
 }
 
@@ -201,8 +210,11 @@ func generateTransactionMethods(content *strings.Builder, entity, repoName strin
 
 // generateMySQLRepositoryWithFields generates MySQL repository with dynamic methods.
 func generateMySQLRepositoryWithFields(dir, entity string, fields []Field, cache, transactions bool, sm ...*SafetyManager) {
-	// For MySQL we use the same logic as PostgreSQL since both use GORM
-	generatePostgresRepositoryWithFields(dir, entity, fields, cache, transactions, sm...)
+	// All SQL databases share the same GORM repository (the concrete driver is
+	// chosen by the dialector in main.go), so they use a single
+	// NewPostgres<Entity>Repository(*gorm.DB) constructor that the DI container
+	// references uniformly.
+	generateGormRepositoryWithFields(dir, entity, "Postgres", fields, cache, transactions, sm...)
 }
 
 // generateMongoRepositoryWithFields generates MongoDB repository with dynamic methods.

--- a/cmd/test_integration.go
+++ b/cmd/test_integration.go
@@ -105,9 +105,11 @@ func generateIntegrationTests(entityName, database string, withFixtures, withCon
 		return fmt.Errorf("failed to create integration directory: %w", err)
 	}
 
+	importPath := getImportPath(getModuleName())
+
 	// Generate main integration test file
 	testFile := filepath.Join(integrationDir, strings.ToLower(entityName)+"_integration_test.go")
-	content := generateIntegrationTestContent(entityName, database, withContainer, fields)
+	content := fixGeneratedModulePath(generateIntegrationTestContent(entityName, database, withContainer, fields), importPath)
 	if err := writeFile(testFile, content, sm...); err != nil {
 		return fmt.Errorf("failed to write integration test file: %w", err)
 	}
@@ -120,7 +122,7 @@ func generateIntegrationTests(entityName, database string, withFixtures, withCon
 		}
 
 		fixtureFile := filepath.Join(fixturesDir, strings.ToLower(entityName)+"_fixtures.go")
-		fixtureContent := generateFixtureContent(entityName, fields)
+		fixtureContent := fixGeneratedModulePath(generateFixtureContent(entityName, fields), importPath)
 		if err := writeFile(fixtureFile, fixtureContent, sm...); err != nil {
 			return fmt.Errorf("failed to write fixture file: %w", err)
 		}
@@ -129,7 +131,7 @@ func generateIntegrationTests(entityName, database string, withFixtures, withCon
 	// Generate database helpers if they don't exist
 	helpersFile := filepath.Join(integrationDir, "helpers.go")
 	if _, err := os.Stat(helpersFile); os.IsNotExist(err) {
-		helpersContent := generateHelpersContent(database, withContainer, entityName)
+		helpersContent := fixGeneratedModulePath(generateHelpersContent(database, withContainer, entityName), importPath)
 		if err := writeFile(helpersFile, helpersContent, sm...); err != nil {
 			return fmt.Errorf("failed to write helpers file: %w", err)
 		}

--- a/cmd/usecase.go
+++ b/cmd/usecase.go
@@ -348,8 +348,11 @@ func generateUseCaseServiceWithFields(dir, usecaseName, entity string, operation
 	// Constructor — return the canonical <Entity>UseCase interface so the
 	// service, handlers and DI container all agree on the type.
 	interfaceName := entity + "UseCase"
-	content.WriteString(fmt.Sprintf("func New%s(repo repository.%sRepository) %s {\n",
-		strings.ToUpper(string(serviceName[0]))+serviceName[1:], entity, interfaceName))
+	// The exported constructor uses the PascalCase entity name (New<Entity>Service)
+	// so it matches the DI container and works for multi-word entities; the
+	// unexported struct keeps its lowercased name.
+	content.WriteString(fmt.Sprintf("func New%sService(repo repository.%sRepository) %s {\n",
+		entity, entity, interfaceName))
 	content.WriteString(fmt.Sprintf("\treturn &%s{repo: repo}\n", serviceName))
 	content.WriteString("}\n\n")
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -193,6 +193,14 @@ func writeGoFileMerged(path, content string, sm ...*SafetyManager) error {
 	return nil
 }
 
+// fixGeneratedModulePath rewrites occurrences of Goca's own module path that
+// leaked into generator templates so generated code imports the user's project
+// packages instead of github.com/sazardev/goca/... (which are internal and
+// unimportable from another module).
+func fixGeneratedModulePath(content, importPath string) string {
+	return strings.ReplaceAll(content, "github.com/sazardev/goca/internal", importPath+"/internal")
+}
+
 // getImportPath determines whether to use the full module path or relative path for imports.
 func getImportPath(moduleName string) string {
 	// Check if we're in a test environment with a GitHub-style fake module


### PR DESCRIPTION
## Summary

A deep, multi-surface audit of v1.25.5 surfaced many independent generator defects. Per request, they are fixed together in **one stabilization PR** (not one PR per bug).

Every fix is verified by generating real projects and compiling/running them.

## Bugs fixed (~10)

**Entities / domain**
- `errors.go` "redeclared": a field named `data` produced `ErrInvalid<Entity>Data`, colliding with the general constant. Error constants are now deduplicated by identifier.

**Use case / DTO**
- The service constructor is now `New<Entity>Service` (PascalCase), matching the DI container and working for multi-word entities (was `NewUserprofileService` for `UserProfile`).

**CLI handler (`--type cli`)**
- Flags and the input struct are derived from the real entity fields (was hardcoded `name`/`email`); prints the whole output struct (was `output.<Entity>`, an undefined field); English command text (was `"crear"`/`"obtener"`).

**Mocks & integration tests**
- Stop hardcoding `github.com/sazardev/goca/internal/...` in generated mocks/fixtures — they're internal/unimportable, so generated code didn't compile. Now rewritten to the user's module path.

**Messages**
- `generateUseCaseMessages` / `generateResponseMessages` are idempotent now (regenerating produced `<Entity>Created redeclared`).

**Integrate / DI**
- `detectExistingFeatures` reconstructs PascalCase from snake_case file names (`user_profile.go → UserProfile`).
- All SQL databases share one GORM repository constructor (`NewPostgres<Entity>Repository(*gorm.DB)`); the DI container and the field-aware repository generator now agree → fixes mysql/sqlserver builds.
- Standalone `goca repository <Entity>` (no `--fields`) recovers fields from the entity and uses the GORM generators, matching the DI container.

**Config**
- Config validation accepts `sqlserver`, `dynamodb`, `elasticsearch`, `postgres-json`. Previously an init-generated **sqlserver** config failed its own load-time validation, so the project silently fell back to defaults (validation disabled) and the use case called a `Validate()` the entity lacked.

**Messages (i18n)**
- The remaining Spanish validator message is now English.

## Verification

- Per-layer and `feature` workflows build for sqlite/postgres/mysql/sqlserver.
- SQLite CRUD (POST/GET/PUT/DELETE) confirmed against a real DB.
- mocks, integration tests, multi-word entities, complex field types (`[]string`, `map`, `*T`, `[]byte`), and the CLI handler all compile.
- Full hooks pass (gofumpt, goimports, staticcheck, golangci-lint, gosec, nilaway, build, `go test -count=1 ./...`) — no bypass.

MongoDB end-to-end DI remains tracked separately in #55 (it needs a Mongo-specific container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
