### PR TITLE
fix: stabilization batch 2 — --wire, --integration-tests and repository --transactions

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -376,8 +376,10 @@ func generateWireGenTemplate(dir string, features []string, sm ...*SafetyManager
 	content.WriteString("package di\n\n")
 	content.WriteString("import (\n")
 	content.WriteString(fmt.Sprintf("\t\"%s/internal/handler/http\"\n", importPath))
-	content.WriteString(")\n\n") // Wire container struct
-	content.WriteString("type Container struct {\n")
+	content.WriteString(")\n\n")
+	// Wire container struct. Named WireContainer to avoid colliding with the
+	// regular Container generated in container.go (same package).
+	content.WriteString("type WireContainer struct {\n")
 	for _, feature := range features {
 		featureLower := strings.ToLower(feature)
 		content.WriteString(fmt.Sprintf("\t%sHandler *http.%sHandler\n", featureLower, feature))
@@ -390,8 +392,8 @@ func generateWireGenTemplate(dir string, features []string, sm ...*SafetyManager
 		featureLower := strings.ToLower(feature)
 		content.WriteString(fmt.Sprintf("\t%sHandler *http.%sHandler,\n", featureLower, feature))
 	}
-	content.WriteString(") *Container {\n")
-	content.WriteString("\treturn &Container{\n")
+	content.WriteString(") *WireContainer {\n")
+	content.WriteString("\treturn &WireContainer{\n")
 	for _, feature := range features {
 		featureLower := strings.ToLower(feature)
 		content.WriteString(fmt.Sprintf("\t\t%sHandler: %sHandler,\n", featureLower, featureLower))
@@ -402,7 +404,7 @@ func generateWireGenTemplate(dir string, features []string, sm ...*SafetyManager
 	// Getters
 	for _, feature := range features {
 		featureLower := strings.ToLower(feature)
-		content.WriteString(fmt.Sprintf("func (c *Container) %sHandler() *http.%sHandler {\n",
+		content.WriteString(fmt.Sprintf("func (c *WireContainer) %sHandler() *http.%sHandler {\n",
 			feature, feature))
 		content.WriteString(fmt.Sprintf("\treturn c.%sHandler\n", featureLower))
 		content.WriteString("}\n\n")

--- a/cmd/repository_fields.go
+++ b/cmd/repository_fields.go
@@ -20,12 +20,14 @@ func generateRepositoryInterfaceWithFields(dir, entity string, fields []Field, t
 		existingContent, err := os.ReadFile(filename)
 		if err == nil {
 			existingStr := string(existingContent)
-			// Remove the final package declaration to avoid duplication
-			if !strings.Contains(existingStr, fmt.Sprintf("type %sRepository interface", entity)) {
-				// Add the existing content without the final newline
-				content.WriteString(strings.TrimSuffix(existingStr, "\n"))
-				content.WriteString("\n\n")
+			// If this entity's interface already exists, leave the file as-is
+			// (rewriting it would drop the package/imports header).
+			if strings.Contains(existingStr, fmt.Sprintf("type %sRepository interface", entity)) {
+				return
 			}
+			// Otherwise append to the existing content (without the trailing newline).
+			content.WriteString(strings.TrimSuffix(existingStr, "\n"))
+			content.WriteString("\n\n")
 		}
 	} else {
 		// File doesn't exist, create header

--- a/cmd/test_integration.go
+++ b/cmd/test_integration.go
@@ -147,7 +147,6 @@ func generateIntegrationTestContent(entityName, database string, withContainer b
 	content := fmt.Sprintf(`package integration
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -168,7 +167,6 @@ func Test%[1]sIntegration(t *testing.T) {
 	repo := repository.NewPostgres%[1]sRepository(db)
 	service := usecase.New%[1]sService(repo)
 
-	ctx := context.Background()
 
 	t.Run("CreateAndRetrieve%[1]s", func(t *testing.T) {
 		// Create test data
@@ -177,13 +175,13 @@ func Test%[1]sIntegration(t *testing.T) {
 		}
 
 		// Create %[3]s
-		output, err := service.Create%[1]s(ctx, input)
+		output, err := service.Create%[1]s(input)
 		require.NoError(t, err)
 		require.NotNil(t, output)
 		assert.NotZero(t, output.ID)
 
 		// Retrieve %[3]s
-		retrieved, err := service.Get%[1]sByID(ctx, output.ID)
+		retrieved, err := service.Get%[1]s(int(output.ID))
 		require.NoError(t, err)
 		require.NotNil(t, retrieved)
 		assert.Equal(t, output.ID, retrieved.ID)
@@ -194,18 +192,15 @@ func Test%[1]sIntegration(t *testing.T) {
 		input := usecase.Create%[1]sInput{
 			// TODO: Add fields
 		}
-		created, err := service.Create%[1]s(ctx, input)
+		created, err := service.Create%[1]s(input)
 		require.NoError(t, err)
 
 		// Update %[3]s
 		updateInput := usecase.Update%[1]sInput{
-			ID: created.ID,
 			// TODO: Add updated fields
 		}
-		updated, err := service.Update%[1]s(ctx, updateInput)
+		err = service.Update%[1]s(int(created.ID), updateInput)
 		require.NoError(t, err)
-		assert.Equal(t, created.ID, updated.ID)
-		// TODO: Add field assertions
 	})
 
 	t.Run("Delete%[1]s", func(t *testing.T) {
@@ -213,15 +208,15 @@ func Test%[1]sIntegration(t *testing.T) {
 		input := usecase.Create%[1]sInput{
 			// TODO: Add fields
 		}
-		created, err := service.Create%[1]s(ctx, input)
+		created, err := service.Create%[1]s(input)
 		require.NoError(t, err)
 
 		// Delete %[3]s
-		err = service.Delete%[1]s(ctx, created.ID)
+		err = service.Delete%[1]s(int(created.ID))
 		require.NoError(t, err)
 
 		// Verify deletion
-		_, err = service.Get%[1]sByID(ctx, created.ID)
+		_, err = service.Get%[1]s(int(created.ID))
 		assert.Error(t, err)
 	})
 
@@ -231,14 +226,14 @@ func Test%[1]sIntegration(t *testing.T) {
 			input := usecase.Create%[1]sInput{
 				// TODO: Add fields with variation
 			}
-			_, err := service.Create%[1]s(ctx, input)
+			_, err := service.Create%[1]s(input)
 			require.NoError(t, err)
 		}
 
 		// List all %[3]ss
-		list, err := service.List%[1]s(ctx)
+		list, err := service.List%[1]ss()
 		require.NoError(t, err)
-		assert.GreaterOrEqual(t, len(list), 3)
+		assert.GreaterOrEqual(t, list.Total, 3)
 	})
 
 	t.Run("Transaction%[1]s", func(t *testing.T) {
@@ -247,14 +242,13 @@ func Test%[1]sIntegration(t *testing.T) {
 			// TODO: Add invalid data to trigger error
 		}
 
-		// This should fail and rollback
-		_, err := service.Create%[1]s(ctx, input)
+		// This should fail validation and not persist anything
+		_, err := service.Create%[1]s(input)
 		assert.Error(t, err)
 
-		// Verify no %[3]s was created
-		list, err := service.List%[1]s(ctx)
+		// Listing should still succeed
+		_, err = service.List%[1]ss()
 		require.NoError(t, err)
-		// TODO: Verify count hasn't increased
 	})
 }
 
@@ -264,7 +258,6 @@ func Test%[1]sRepositoryIntegration(t *testing.T) {
 	defer cleanupTestDatabase(t, db)
 
 	repo := repository.NewPostgres%[1]sRepository(db)
-	ctx := context.Background()
 
 	t.Run("SaveAndFindByID", func(t *testing.T) {
 		%[3]s := &domain.%[1]s{
@@ -272,12 +265,12 @@ func Test%[1]sRepositoryIntegration(t *testing.T) {
 		}
 
 		// Save
-		err := repo.Save(ctx, %[3]s)
+		err := repo.Save(%[3]s)
 		require.NoError(t, err)
 		assert.NotZero(t, %[3]s.ID)
 
 		// Find by ID
-		found, err := repo.FindByID(ctx, %[3]s.ID)
+		found, err := repo.FindByID(int(%[3]s.ID))
 		require.NoError(t, err)
 		assert.Equal(t, %[3]s.ID, found.ID)
 	})
@@ -288,12 +281,12 @@ func Test%[1]sRepositoryIntegration(t *testing.T) {
 			%[3]s := &domain.%[1]s{
 				// TODO: Add fields
 			}
-			err := repo.Save(ctx, %[3]s)
+			err := repo.Save(%[3]s)
 			require.NoError(t, err)
 		}
 
 		// Find all
-		all, err := repo.FindAll(ctx)
+		all, err := repo.FindAll()
 		require.NoError(t, err)
 		assert.GreaterOrEqual(t, len(all), 5)
 	})
@@ -302,15 +295,15 @@ func Test%[1]sRepositoryIntegration(t *testing.T) {
 		%[3]s := &domain.%[1]s{
 			// TODO: Add fields
 		}
-		err := repo.Save(ctx, %[3]s)
+		err := repo.Save(%[3]s)
 		require.NoError(t, err)
 
 		// Delete
-		err = repo.Delete(ctx, %[3]s.ID)
+		err = repo.Delete(int(%[3]s.ID))
 		require.NoError(t, err)
 
 		// Verify deletion
-		_, err = repo.FindByID(ctx, %[3]s.ID)
+		_, err = repo.FindByID(int(%[3]s.ID))
 		assert.Error(t, err)
 	})
 }
@@ -518,6 +511,11 @@ func seedTestData(t *testing.T, db *gorm.DB) {
 	//     }
 	// }
 }
+
+// ptr returns a pointer to v. Handy for the optional pointer fields of Update DTOs.
+func ptr[T any](v T) *T {
+	return &v
+}
 `, containerSetup)
 	return replaceHelperTODOs(content, entityName)
 }
@@ -633,7 +631,8 @@ func buildTestFieldInitUpdated(fields []Field, entity, indent string) string {
 		if skipTestField(f.Name) {
 			continue
 		}
-		lines = append(lines, fmt.Sprintf("%s%s: %s,", indent, f.Name, updatedTestLiteral(f.Name, f.Type, entity)))
+		// Update DTO fields are pointers; wrap the value with the ptr() helper.
+		lines = append(lines, fmt.Sprintf("%s%s: ptr(%s),", indent, f.Name, updatedTestLiteral(f.Name, f.Type, entity)))
 	}
 	return strings.Join(lines, "\n")
 }
@@ -723,7 +722,7 @@ func replaceIntegrationTestTODOs(content string, fields []Field, entityName stri
 
 	useFmt := needsFmtImport(fields)
 	if useFmt {
-		content = strings.Replace(content, "\t\"context\"\n", "\t\"context\"\n\t\"fmt\"\n", 1)
+		content = strings.Replace(content, "\t\"testing\"\n", "\t\"fmt\"\n\t\"testing\"\n", 1)
 	}
 
 	createInit := buildTestFieldInit(fields, entityName, "\t\t\t")

--- a/cmd/test_integration_helpers_test.go
+++ b/cmd/test_integration_helpers_test.go
@@ -142,8 +142,8 @@ func TestBuildTestFieldInitUpdated(t *testing.T) {
 	}
 
 	result := buildTestFieldInitUpdated(fields, "Product", "\t\t\t")
-	assert.Contains(t, result, `Email: "updated@product.com",`)
-	assert.Contains(t, result, "Price: 19.99,")
+	assert.Contains(t, result, `Email: ptr("updated@product.com"),`)
+	assert.Contains(t, result, "Price: ptr(19.99),")
 	assert.NotContains(t, result, "ID:")
 }
 
@@ -226,8 +226,9 @@ func TestGenerateIntegrationTestContent_WithFields(t *testing.T) {
 	assert.Contains(t, content, "Age: 1")
 	// Should have fmt import for varied data
 	assert.Contains(t, content, `"fmt"`)
-	// Should have assertions
-	assert.Contains(t, content, "assert.Equal(t, updateInput.Name, updated.Name)")
+	// Update DTO fields are pointers and the call matches the real API
+	assert.Contains(t, content, `Name: ptr("Updated User")`)
+	assert.Contains(t, content, "err = service.UpdateUser(int(created.ID), updateInput)")
 }
 
 func TestGenerateIntegrationTestContent_WithoutFields(t *testing.T) {


### PR DESCRIPTION
## Summary

A deep per-flag audit of v1.25.6 (generating projects, then compiling/vetting/running them) found several flags producing broken output. Fixed together in one stabilization PR.

## Bugs fixed

**`goca di --wire`**
- The Wire container was emitted as `type Container`, colliding with the regular `container.go` in the same package → `Container redeclared`. It's now `WireContainer` (struct, constructor return type and method receivers).

**`--integration-tests` / `goca test-integration`**
- The generated integration tests were entirely out of sync with the real use-case/repository API and didn't compile. The template was rewritten to match the actually-generated code:
  - no `ctx` argument (the generated use cases/repositories don't take one);
  - `Get<E>(int(id))` instead of `Get<E>ByID(ctx, …)`;
  - `List<E>s()` returning `List<E>Output` (asserts on `.Total`) instead of `List<E>(ctx)` over a slice;
  - `Update<E>(int(id), input)` returning only `error` (was assigned a non-existent result);
  - repository calls without `ctx` (`Save`/`FindByID`/`FindAll`/`Delete`);
  - Update DTO fields are pointers — values are wrapped with a generated `ptr[T any]` helper added to `helpers.go`;
  - fixed the `fmt` import insertion anchor.

**`goca repository --transactions` (and re-running `repository`)**
- `generateRepositoryInterfaceWithFields` now returns early when the entity's interface already exists. Previously it rewrote `interfaces.go` without the package/imports header → `expected 'package', found 'type'`.

## Verification

- Every flag combination above builds and `go vet`s clean.
- SQLite CRUD (`POST`/`GET`/`PUT`/`DELETE` → 201/200/204/204) works at runtime on a project generated **with** `--integration-tests`.
- Full hooks pass (gofumpt, goimports, staticcheck, golangci-lint, gosec, nilaway, build, `go test -count=1 ./...`) — no bypass. Updated the goca tests that asserted the old integration-test template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
